### PR TITLE
Fix broken behaviour on macOs 

### DIFF
--- a/runebuf.go
+++ b/runebuf.go
@@ -535,7 +535,7 @@ func (r *RuneBuffer) getBackspaceSequence() []byte {
 		buf = append(buf, '\b')
 		if sep[i] {
 			// up one line, go to the start of the line and move cursor right to the end (r.width)
-			buf = append(buf, "\033[A\r"+"\033["+strconv.Itoa(r.width)+"C"...)
+			buf = append(buf, "\r"+"\033["+strconv.Itoa(r.width)+"C"...)
 		}
 	}
 


### PR DESCRIPTION
I ran into a bug where navigating back to a previous line leads to the cursor moving up two lines and pulling the prompt along with it. I saw this behavior in the readline-demo and in ollama.

Context: https://github.com/jmorganca/ollama/pull/578#issuecomment-1732171873

This patch seems to fix it for me, but I have not been able to test on other platforms than macOs.